### PR TITLE
Fix flood rate calculation on 1.1.0

### DIFF
--- a/Resources/Client/floodBeamMP/lua/ge/extensions/floodBeamMP.lua
+++ b/Resources/Client/floodBeamMP/lua/ge/extensions/floodBeamMP.lua
@@ -109,7 +109,7 @@ local function onUpdate(dt)
     end
 
     setWaterLevel(newLevel)
-    serverWaterLevel = serverWaterLevel + ((decreasing and -1 or 1) * floodSpeed * 1000) * dt
+    serverWaterLevel = serverWaterLevel + ((decreasing and -1 or 1) * floodSpeed) * dt
 end
 
 local function onClientEndMission()

--- a/Resources/Server/Flood/flood.lua
+++ b/Resources/Server/Flood/flood.lua
@@ -119,7 +119,7 @@ function T_Update()
     if not M.isOceanValid or not M.options.enabled then return end
 
     local level = M.options.oceanLevel
-    local changeAmount = UPDATE_TIME * M.options.floodSpeed
+    local changeAmount = M.options.floodSpeed
     local limit = M.options.limit
     local decrease = M.options.decrease
     local resetAt = M.options.resetAt

--- a/automod.ps1
+++ b/automod.ps1
@@ -33,7 +33,7 @@ if (!(Test-Path $BeamMPResourcePath)) {
 
 # Watcher stuff
 $Watcher = New-Object System.IO.FileSystemWatcher
-$Watcher.Path = $ModPath
+$Watcher.Path = Resolve-Path -Path $ModPath
 $Watcher.NotifyFilter = [System.IO.NotifyFilters]::LastWrite, [System.IO.NotifyFilters]::FileName, [System.IO.NotifyFilters]::DirectoryName
 $Watcher.Filter = "*.*"
 $Watcher.IncludeSubdirectories = $true


### PR DESCRIPTION
I noticed there was an issue with how the flood rate was calculated, it is now correctly calculated as ±`changeAmount` every `UPDATE_RATE`ms. The client doesn't need to have the rate hardcoded because the it only gets sent changes by the server at the rate of the server.

This does however change how the speed is scaled, so for example, a speed of 0.65 will change the elevation by 0.65 units every `UPDATE_RATE`ms, but I think that's what you initially intended anyway.

I have tested these changes on my private server and they appear to be working properly, even with different update rates.

Also, fixed an issue with the automod script that prevented the file watcher from working on network drives.